### PR TITLE
JSON writer: Include CSV filename data

### DIFF
--- a/src/CsvInterpreter.py
+++ b/src/CsvInterpreter.py
@@ -59,5 +59,6 @@ class Column:
 
         for i in range(min(len(self.examples), 10)):
             examples_list += '"%s":[],' %(self.examples[i])
-        examples_list += '"tag":[{ "id":"%s" }]}' %(self.id)
+        examples_list += '"tag":[{ "id":"%s" }],' %(self.id)
+        examples_list += '"file_data":[{ "name":"%s" }]}' %(self.source.filename)
         return start + examples_list


### PR DESCRIPTION
We want to be able to show the user where the data that's been classified is coming from. This adds a new JSON key called `file_data` that includes a `name`.